### PR TITLE
fix: prevent PreviewFrame double-render when switching tabs

### DIFF
--- a/src/app/__tests__/main-content.test.tsx
+++ b/src/app/__tests__/main-content.test.tsx
@@ -1,0 +1,161 @@
+import { test, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MainContent } from "@/app/main-content";
+
+// Mock ResizeObserver (required by Radix UI and react-resizable-panels)
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock resizable panels
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  ),
+  ResizablePanel: ({ children }: any) => <div>{children}</div>,
+  ResizableHandle: () => <div />,
+}));
+
+// Mock heavy child components
+vi.mock("@/components/chat/ChatInterface", () => ({
+  ChatInterface: () => <div data-testid="chat-interface">Chat</div>,
+}));
+
+vi.mock("@/components/preview/PreviewFrame", () => ({
+  PreviewFrame: () => <div data-testid="preview-frame">Preview Frame</div>,
+}));
+
+vi.mock("@/components/editor/FileTree", () => ({
+  FileTree: () => <div data-testid="file-tree">File Tree</div>,
+}));
+
+vi.mock("@/components/editor/CodeEditor", () => ({
+  CodeEditor: () => <div data-testid="code-editor">Code Editor</div>,
+}));
+
+vi.mock("@/components/HeaderActions", () => ({
+  HeaderActions: () => <div>Header Actions</div>,
+}));
+
+// Mock AI SDK
+vi.mock("@ai-sdk/react", () => ({
+  useChat: () => ({
+    messages: [],
+    input: "",
+    handleInputChange: vi.fn(),
+    handleSubmit: vi.fn(),
+    status: "idle",
+    append: vi.fn(),
+    setMessages: vi.fn(),
+    stop: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+// Mock VirtualFileSystem
+vi.mock("@/lib/file-system", () => ({
+  VirtualFileSystem: vi.fn().mockImplementation(() => ({
+    createFile: vi.fn(),
+    updateFile: vi.fn(),
+    deleteFile: vi.fn(),
+    rename: vi.fn().mockReturnValue(false),
+    readFile: vi.fn().mockReturnValue(null),
+    getAllFiles: vi.fn().mockReturnValue(new Map()),
+    createFileWithParents: vi.fn().mockReturnValue(""),
+    replaceInFile: vi.fn().mockReturnValue(""),
+    insertInFile: vi.fn().mockReturnValue(""),
+    getNode: vi.fn().mockReturnValue({
+      type: "directory",
+      name: "",
+      path: "/",
+      children: new Map(),
+    }),
+    serialize: vi.fn().mockReturnValue({}),
+    reset: vi.fn(),
+    deserializeFromNodes: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/anon-work-tracker", () => ({
+  setHasAnonWork: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+test("shows Preview view by default", () => {
+  render(<MainContent />);
+
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+  expect(screen.queryByTestId("file-tree")).toBeNull();
+});
+
+test("clicking Code tab switches to code view", () => {
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  fireEvent.click(codeTab);
+
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+  expect(screen.getByTestId("file-tree")).toBeDefined();
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+});
+
+test("clicking Preview tab after Code tab restores preview view", () => {
+  render(<MainContent />);
+
+  // Switch to code view
+  fireEvent.click(screen.getByRole("tab", { name: "Code" }));
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+
+  // Switch back to preview
+  fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+  expect(screen.queryByTestId("file-tree")).toBeNull();
+});
+
+test("Preview tab has active state by default", () => {
+  render(<MainContent />);
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+
+  expect(previewTab.getAttribute("data-state")).toBe("active");
+  expect(codeTab.getAttribute("data-state")).toBe("inactive");
+});
+
+test("Code tab becomes active after clicking it", () => {
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  fireEvent.click(codeTab);
+
+  expect(codeTab.getAttribute("data-state")).toBe("active");
+  expect(screen.getByRole("tab", { name: "Preview" }).getAttribute("data-state")).toBe(
+    "inactive"
+  );
+});
+
+test("tabs can be toggled multiple times", () => {
+  render(<MainContent />);
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+
+  // Preview → Code → Preview → Code
+  fireEvent.click(codeTab);
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+
+  fireEvent.click(previewTab);
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+
+  fireEvent.click(codeTab);
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+});

--- a/src/components/preview/PreviewFrame.tsx
+++ b/src/components/preview/PreviewFrame.tsx
@@ -13,17 +13,12 @@ export function PreviewFrame() {
   const { getAllFiles, refreshTrigger } = useFileSystem();
   const [error, setError] = useState<string | null>(null);
   const [entryPoint, setEntryPoint] = useState<string>("/App.jsx");
-  const [isFirstLoad, setIsFirstLoad] = useState(true);
+  const isFirstLoadRef = useRef(true);
 
   useEffect(() => {
     const updatePreview = () => {
       try {
         const files = getAllFiles();
-
-        // Clear error first when we have files
-        if (files.size > 0 && error) {
-          setError(null);
-        }
 
         // Find the entry point - look for App.jsx, App.tsx, index.jsx, or index.tsx
         let foundEntryPoint = entryPoint;
@@ -54,7 +49,7 @@ export function PreviewFrame() {
         }
 
         if (files.size === 0) {
-          if (isFirstLoad) {
+          if (isFirstLoadRef.current) {
             setError("firstLoad");
           } else {
             setError("No files to preview");
@@ -63,9 +58,7 @@ export function PreviewFrame() {
         }
 
         // We have files, so it's no longer the first load
-        if (isFirstLoad) {
-          setIsFirstLoad(false);
-        }
+        isFirstLoadRef.current = false;
 
         if (!foundEntryPoint || !files.has(foundEntryPoint)) {
           setError(
@@ -96,7 +89,7 @@ export function PreviewFrame() {
     };
 
     updatePreview();
-  }, [refreshTrigger, getAllFiles, entryPoint, error, isFirstLoad]);
+  }, [refreshTrigger, getAllFiles, entryPoint]);
 
   if (error) {
     if (error === "firstLoad") {


### PR DESCRIPTION
Fixes #2

The `useEffect` in `PreviewFrame` had `error` and `isFirstLoad` in its dependency array, but both were set inside the effect. This caused the effect to run twice on every mount, making the iframe reload twice every time the Preview tab was shown.

Replace `isFirstLoad` state with a ref and remove `error` from the dependency array. Also adds tests for the toggle button behavior.

Generated with [Claude Code](https://claude.ai/code)